### PR TITLE
Allow rendering of hyperlinks for most cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vercel
 *.txt
 *.docx
+venv/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-This script scrapes any NZ Herald article and outputs the content to a text file. 
-Directly use my webapp hosted on: https://nzherald.vercel.app/
+Scrape any NZHerald article using --> https://nzherald.vercel.app/
 
 # Instructions
 - ```pip install beautifulsoup4```
@@ -14,9 +13,9 @@ Directly use my webapp hosted on: https://nzherald.vercel.app/
 
 ## Running the front end locally
 - ```cd NZHerald Article Scraper\frontend```
-- ```npm run build```
+- Compile the code: ```npm run build```
 - ```npm install -g serve```
-- ```serve -s build -l 3000```
+- Run the app on localhost port 3000: ```serve -s build -l 3000```
 - Enter the NZH article URL
 - Article content is displayed to the screen
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, request, jsonify, render_template
 from flask_cors import CORS
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString, Tag
 import requests
 import urllib.parse
 
@@ -43,6 +43,7 @@ def scrape_data():
 
         return jsonify({"fetchStatus": f"Error when fetching article from {url}:\n {str(e)} 💀💀💀"}), 500
 
+# Filtering only wanted HTML elements
 def is_wanted_element(elem):
     # Onlt include images with a source
     if elem.name == 'img':
@@ -55,6 +56,24 @@ def is_wanted_element(elem):
         return False
     return True  # Keep p or other li
 
+# Serializing <p>/<li> tags' content into text to be rendered as HTML in frontend
+def serialize_paragraph(elem: Tag):
+    parts = []
+    for child in elem.children:
+        if isinstance(child, NavigableString):
+            parts.append(str(child))
+        elif child.name == 'a':
+            href = child.get('href')
+            text = child.string or child.get_text(strip=True)
+            if href:
+                parts.append(f'<a href="{href}" target="_blank" rel="noreferrer">{text}</a>')
+            else:
+                parts.append(text)
+        else:
+            parts.append(child.get_text())
+    return ''.join(parts)
+
+# Handles retrieving the text for all kinds of HTML tags
 def returnTagText(article_sections):
     content = []
     for article_section in article_sections:
@@ -62,7 +81,7 @@ def returnTagText(article_sections):
             article_elements = list(filter(is_wanted_element, article_section.find_all(['p', 'li', 'img'])))
             for elem in article_elements:
                 if elem.name == 'p' or elem.name == 'li':
-                    content.append({'type': 'text', 'content': elem.text})
+                    content.append({'type': 'text', 'content': elem.decode_contents()})
                 elif elem.name == 'img':
                     caption = None
                     alt = elem.get('alt', "Image goes here")
@@ -74,6 +93,7 @@ def returnTagText(article_sections):
                     content.append({'type': 'image', 'src': elem.get("data-src") or elem['src'], 'srcset': elem.get("data-srcset") or elem.get("srcset"), 'alt': alt, 'caption': caption})
     return content
 
+# Determines which sections of the article to scrape
 def scrapeContent(url):
     title = "Title not found"
     content = []

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -88,6 +88,10 @@ figcaption {
   font-size: .875rem;
 }
 
+a {
+  color: cornflowerblue;
+}
+
 .sentenceStyle {
   font-family: Inter-variable, Arial, Helvetica, sans-serif;
   font-size: 16px;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,7 +75,11 @@ function App() {
           <h1 className='titleStyle'>{title}</h1>
           {content.map((item, index) => {
             if (item.type === 'text') {
-              return <p className='sentenceStyle' key={index}>{item.content}</p>;
+              return <p 
+                      className='sentenceStyle'
+                      key={index}
+                      dangerouslySetInnerHTML={{ __html: item.content }}>
+                     </p>;
             } else if (item.type === 'image') {
               return (
                 <figure key={index}>


### PR DESCRIPTION
Fixed most hyperlinks to be displayed. If they're "problematic", only the plain text is displayed...

But the HTML and url should not be displayed anymore!